### PR TITLE
Initial HTML abstraction

### DIFF
--- a/projector-html/ambiata-projector-html.cabal
+++ b/projector-html/ambiata-projector-html.cabal
@@ -16,6 +16,8 @@ library
                      , ambiata-p
                      , ambiata-x-eithert
                      , ambiata-projector-core
+                     , containers
+                     , text                            == 1.2.*
                      , transformers                    >= 0.4        && < 0.6
 
   ghc-options:
@@ -28,6 +30,8 @@ library
                        Paths_ambiata_projector_html
 
                        Projector.Html
+                       Projector.Html.Core.Library
+                       Projector.Html.Core.Prim
 
 test-suite test
   type:                exitcode-stdio-1.0

--- a/projector-html/src/Projector/Html/Core/Library.hs
+++ b/projector-html/src/Projector/Html/Core/Library.hs
@@ -1,0 +1,110 @@
+-- | This is the HTML abstraction that users interact with.
+-- Backends may choose to transform it into something else.
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Projector.Html.Core.Library (
+    types
+  ) where
+
+
+import qualified Data.Map.Strict as M
+
+import           P
+
+import           Projector.Core
+import           Projector.Html.Core.Prim (HtmlType, HtmlDecl, HtmlDecls)
+import qualified Projector.Html.Core.Prim as Prim
+
+
+types :: HtmlDecls
+types =
+  TypeDecls $ M.fromList [
+      (nTag, dTag)
+    , (nAttribute, dAttribute)
+    , (nAttributeKey, dAttributeKey)
+    , (nAttributeValue, dAttributeValue)
+    , (nHtml, dHtml)
+    ]
+
+-- -----------------------------------------------------------------------------
+
+nTag :: TypeName
+nTag =
+  TypeName "Tag"
+
+tTag :: HtmlType
+tTag =
+  TVar nTag
+
+dTag :: HtmlDecl
+dTag =
+  DVariant [
+      (Constructor "Tag", [TLit Prim.TString])
+    ]
+
+-- -----------------------------------------------------------------------------
+
+nAttribute :: TypeName
+nAttribute =
+  TypeName "Attribute"
+
+tAttribute :: HtmlType
+tAttribute =
+  TVar nAttribute
+
+dAttribute :: HtmlDecl
+dAttribute =
+  DVariant [
+      (Constructor "Attribute", [tAttributeKey, tAttributeValue])
+    ]
+
+-- -----------------------------------------------------------------------------
+
+nAttributeKey :: TypeName
+nAttributeKey =
+  TypeName "AttributeKey"
+
+tAttributeKey :: HtmlType
+tAttributeKey =
+  TVar nAttributeKey
+
+dAttributeKey :: HtmlDecl
+dAttributeKey =
+  DVariant [
+      (Constructor "AttributeKey", [TLit Prim.TString])
+    ]
+
+-- -----------------------------------------------------------------------------
+
+nAttributeValue :: TypeName
+nAttributeValue =
+  TypeName "AttributeValue"
+
+tAttributeValue :: HtmlType
+tAttributeValue =
+  TVar nAttributeValue
+
+dAttributeValue :: HtmlDecl
+dAttributeValue =
+  DVariant [
+      (Constructor "AttributeValue", [TLit Prim.TString])
+    ]
+
+-- -----------------------------------------------------------------------------
+
+nHtml :: TypeName
+nHtml =
+  TypeName "Html"
+
+tHtml :: HtmlType
+tHtml =
+  TVar nHtml
+
+dHtml :: HtmlDecl
+dHtml =
+  DVariant [
+      (Constructor "Element", [tTag, TList tAttribute, TList tHtml])
+    , (Constructor "VoidElement", [tTag, TList tAttribute])
+    , (Constructor "Comment", [TLit Prim.TString])
+    , (Constructor "Plain", [TLit Prim.TString])
+    ]

--- a/projector-html/src/Projector/Html/Core/Prim.hs
+++ b/projector-html/src/Projector/Html/Core/Prim.hs
@@ -1,0 +1,70 @@
+-- | Everything in this module must be made available in the target
+-- prior to codegen. i.e. these are the primitives we assume.
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+module Projector.Html.Core.Prim (
+    HtmlType
+  , HtmlDecl
+  , HtmlDecls
+  , HtmlExpr
+  , PrimT (..)
+  , types
+  , tBool
+  , dBool
+  ) where
+
+
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+
+import           P
+
+import           Projector.Core
+
+
+type HtmlType = Type PrimT
+type HtmlDecl = Decl PrimT
+type HtmlDecls = TypeDecls PrimT
+type HtmlExpr = Expr PrimT
+
+data PrimT
+  = TString
+  deriving (Eq, Ord, Read, Show)
+
+instance Ground PrimT where
+  data Value PrimT
+    = VString Text
+    deriving (Eq, Ord, Read, Show)
+
+  typeOf v = case v of
+    VString _ -> TString
+
+  ppGroundType t = case t of
+    TString -> "String"
+
+  ppGroundValue v = case v of
+    VString s ->
+      T.pack (show s)
+
+types :: HtmlDecls
+types =
+  TypeDecls $ M.fromList [
+      (nBool, dBool)
+    ]
+
+
+nBool :: TypeName
+nBool =
+  TypeName "Bool"
+
+tBool :: HtmlType
+tBool =
+  TVar nBool
+
+dBool :: HtmlDecl
+dBool =
+  DVariant [
+      (Constructor "True", [])
+    , (Constructor "False", [])
+    ]


### PR DESCRIPTION
First implementation of the HTML types.

We have all the features we need to write a single template now (still missing some form of Let).

For those playing at home, the idea is:
- Users write templates in terms of this Html datatype
- Backends can compile syntactically (where the target language also has a Html datatype with the same semantics), or do something more aggressive (like switch out the meaning of the Html type entirely, replacing all constructor occurrences)

! @charleso @jystic 