### PR TITLE
Add projector-core-test

### DIFF
--- a/projector-core/test/ambiata-projector-core-test.cabal
+++ b/projector-core/test/ambiata-projector-core-test.cabal
@@ -1,0 +1,33 @@
+name:                  ambiata-projector-core-test
+version:               0.0.1
+license:               AllRightsReserved
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2016 Ambiata.
+synopsis:              ambiata-projector-core-test
+category:              System
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           ambiata-projector-core-test
+
+library
+  ghc-options:
+                       -Wall
+
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-disorder-core
+                     , ambiata-disorder-corpus
+                     , ambiata-disorder-jack
+                     , ambiata-p
+                     , ambiata-projector-core
+                     , QuickCheck                      >= 2.8.2      && < 2.9
+                     , quickcheck-instances            == 0.3.*
+                     , comonad                         == 5.*
+                     , mtl
+                     , containers                      == 0.5.*
+                     , text                            == 1.2.*
+                     , semigroups
+
+  exposed-modules:
+                     Test.Projector.Core.Arbitrary

--- a/projector-html/ambiata-projector-html.cabal
+++ b/projector-html/ambiata-projector-html.cabal
@@ -67,6 +67,7 @@ test-suite test
                      , ambiata-disorder-jack
                      , ambiata-p
                      , ambiata-projector-core
+                     , ambiata-projector-core-test
                      , ambiata-projector-html
                      , ambiata-projector-html-runtime
                      , QuickCheck                      >= 2.8.2      && < 2.9
@@ -89,6 +90,7 @@ test-suite test-io
                      , ambiata-disorder-jack
                      , ambiata-p
                      , ambiata-projector-core
+                     , ambiata-projector-core-test
                      , ambiata-projector-html
                      , ambiata-projector-html-runtime
                      , QuickCheck                      >= 2.8.2      && < 2.9


### PR DESCRIPTION
Need the well-typed generators to produce sensible templates.

Not sure of the current way to get a boris build going for cabal-test, doesn't matter much since it'll be used in the html build.

! @charleso @nhibberd 