### PR TITLE
Stash types in AST

### DIFF
--- a/projector-core/src/Projector/Core/Pretty.hs
+++ b/projector-core/src/Projector/Core/Pretty.hs
@@ -209,13 +209,13 @@ ppExpr' types e =
       WL.annotate a $ WL.parens (text n WL.<> text "#" WL.<> text (typeMay ty))
   where typeMay t = if types then " : " <> ppType t else T.empty
 
-ppPattern :: Pattern a -> Text
+ppPattern :: Pattern -> Text
 ppPattern p =
   case p of
-    PVar _ (Name n) ->
+    PVar (Name n) ->
       n
 
-    PCon _ (Constructor c) ps ->
+    PCon (Constructor c) ps ->
       c <> " " <> T.unwords (fmap (parenMay . ppPattern) ps)
 
 hasSpace :: Text -> Bool

--- a/projector-core/src/Projector/Core/Simplify.hs
+++ b/projector-core/src/Projector/Core/Simplify.hs
@@ -149,14 +149,14 @@ nf' ctx expr =
     expr
 
 -- | Pattern matching. Returns 'Nothing' if no match is possible.
-match :: Map Name (Expr l a) -> Pattern a -> Expr l a -> Maybe (Map Name (Expr l a))
+match :: Map Name (Expr l a) -> Pattern -> Expr l a -> Maybe (Map Name (Expr l a))
 match ctx pat expr =
   case (pat, expr) of
-    (PVar _ n, e) ->
+    (PVar n, e) ->
       -- Variable patterns always succeed.
       pure (M.insert n e ctx)
 
-    (PCon _ c1 ps, ECon _ c2 _ es) ->
+    (PCon c1 ps, ECon _ c2 _ es) ->
       -- Constructor names and arity have to match.
       if (c1 == c2) && (length ps == length es)
         then foldM (\ctx' (p, e) -> match ctx' p e) ctx (L.zip ps es)
@@ -220,16 +220,16 @@ alpha' rebinds rename expr =
     EForeign _ _ _ ->
       pure expr
 
-alphaPat' :: Map Name Name -> (Name -> Name) -> Pattern a -> State (Map Name Int) (Pattern a, Map Name Name)
+alphaPat' :: Map Name Name -> (Name -> Name) -> Pattern -> State (Map Name Int) (Pattern, Map Name Name)
 alphaPat' rebinds rename p =
   case p of
-    PVar a x -> do
+    PVar x -> do
       new <- freshen (rename x)
-      pure (PVar a new, M.insert x new rebinds)
+      pure (PVar new, M.insert x new rebinds)
 
-    PCon a c pats -> do
+    PCon c pats -> do
       (pats', rebinds') <- foldM (accum rename) ([], rebinds) pats
-      pure (PCon a c (L.reverse pats'), rebinds')
+      pure (PCon c (L.reverse pats'), rebinds')
 
   where
     accum rename' (acc, rebinds') p2 = do

--- a/projector-core/test/Test/Projector/Core/Arbitrary.hs
+++ b/projector-core/test/Test/Projector/Core/Arbitrary.hs
@@ -117,13 +117,13 @@ genCon t v =
     <*> t
     <*> listOf v
 
-genCase :: Jack (Expr l ()) -> Jack (Pattern ()) -> Jack (Expr l ())
+genCase :: Jack (Expr l ()) -> Jack Pattern -> Jack (Expr l ())
 genCase e p =
   case_
     <$> e
     <*> (fmap NE.toList (listOf1 $ (,) <$> p <*> e))
 
-genPattern :: Jack Constructor -> Jack Name -> Jack (Pattern ())
+genPattern :: Jack Constructor -> Jack Name -> Jack Pattern
 genPattern c n =
   oneOfRec [fmap pvar n] [pcon <$> c <*> listOf (genPattern c n)]
 
@@ -375,7 +375,7 @@ genAlternatives ::
   -> (Context l -> Type l -> Jack (Expr l ()))
   -> [(Constructor, [Type l])]
   -> Type l
-  -> Jack [(Pattern (), Expr l ())]
+  -> Jack [(Pattern, Expr l ())]
 genAlternatives ctx names more cts want =
   for cts $ \(c, tys) -> do
     let bnds = L.take (length tys) (freshNames "x")

--- a/projector-html/src/Projector/Html/Backend/Haskell.hs
+++ b/projector-html/src/Projector/Html/Backend/Haskell.hs
@@ -153,17 +153,17 @@ genExp expr =
       varE (mkName_ x)
 
 -- | Case alternatives.
-genMatch :: Pattern a -> HtmlExpr a -> TH.Match
+genMatch :: Pattern -> HtmlExpr a -> TH.Match
 genMatch p e =
   match_ (genPat p) (genExp e)
 
 -- | Patterns.
-genPat :: Pattern a -> TH.Pat
+genPat :: Pattern -> TH.Pat
 genPat p = case p of
-  PVar _ (Name n) ->
+  PVar (Name n) ->
     varP (mkName_ n)
 
-  PCon _ (Constructor n) ps ->
+  PCon (Constructor n) ps ->
     conP (mkName_ n) (fmap genPat ps)
 
 -- | Literals.

--- a/projector-html/src/Projector/Html/Core/Elaborator.hs
+++ b/projector-html/src/Projector/Html/Core/Elaborator.hs
@@ -107,17 +107,18 @@ eExpr expr =
     TECase a e alts ->
       ECase a (eExpr e) (NE.toList (fmap eAlt alts))
 
-eAlt :: TAlt a -> (Pattern a, HtmlExpr a)
+eAlt :: TAlt a -> (Pattern, HtmlExpr a)
 eAlt (TAlt _ pat body) =
   (ePat pat, eAltBody body)
 
-ePat :: TPattern a -> Pattern a
+ePat :: TPattern a -> Pattern
 ePat pat =
+  -- TODO find something we can do with these annotations
   case pat of
-    TPVar a (TId x) ->
-      PVar a (Name x)
-    TPCon a (TConstructor x) pats ->
-      PCon a (Constructor x) (fmap ePat pats)
+    TPVar _ (TId x) ->
+      PVar (Name x)
+    TPCon _ (TConstructor x) pats ->
+      PCon (Constructor x) (fmap ePat pats)
 
 eAltBody :: TAltBody a -> HtmlExpr a
 eAltBody body =


### PR DESCRIPTION
Record types as annotations.

I want to end up with something closer to `Either TypeError Type` as the annotation, as that would let us keep typechecking things in parallel (with a `traverse` to assert the program is well-typed). As it stands a type error in an unrelated AST node can suppress neighbouring type errors. Good enough for now though

! @charleso @jystic 