### PR TITLE
WIP top level recursive let

### DIFF
--- a/projector-core/src/Projector/Core/Check.hs
+++ b/projector-core/src/Projector/Core/Check.hs
@@ -80,7 +80,7 @@ typeCheckAll' ::
   => Map Name (Either [TypeError l a] (Expr l (Type l, a)))
   -> Either [TypeError l a] (Map Name (Expr l (Type l, a)))
 typeCheckAll' =
-  sequenceA -- probably want to gather all the errors here
+  sequenceE
 
 -- -----------------------------------------------------------------------------
 

--- a/projector-core/src/Projector/Core/Pretty.hs
+++ b/projector-core/src/Projector/Core/Pretty.hs
@@ -114,6 +114,9 @@ ppTypeError' err =
            [ "Pattern matches are non-exhaustive for an expression of type"
            , ppType ty
            ])
+    Blackholed _es a ->
+      WL.annotate a $
+        text "Typechecking blocked by other type errors"
 
 -- -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This doesn't quite work, I need to finish the constraint solver first so that it terminates, but wanted to share what I've got planned here.

We lazily explore a map of thunks, recursively. I like the map of thunks as we can serialize the results and populate it from disk as needed on subsequent invocations, the function doesn't need to know where the results came from. We can explore the map as needed (typecheck a subset of modules) or force it all at once using `sequenceA`.

The knot-tying implementation of let is kinda neat I think! but requires a constraint-based typechecker to terminate, some ill-typed programs can make it diverge.

This change admits general recursion. The termination checker is much lower-priority and will be a separate component, likely running after typechecking over this map of annotated ASTs. I'll be using the call graph in the meantime, rejecting any call graphs that don't form a DAG.