### PR TITLE
Type functor

### DIFF
--- a/projector-core/src/Projector/Core/Pretty.hs
+++ b/projector-core/src/Projector/Core/Pretty.hs
@@ -128,10 +128,10 @@ ppTypeInfo ctx =
 ppType' :: Ground l => TypeDecls l -> Bool -> Type l -> Text
 ppType' ctx verbose t =
   case t of
-    TLit g ->
+    Type (TLitF g) ->
       ppGroundType g
 
-    TVar tn@(TypeName ty) ->
+    Type (TVarF tn@(TypeName ty)) ->
       let mty = lookupType tn ctx
       in ty <> case (verbose, mty) of
            (True, Just (DVariant cts)) ->
@@ -141,10 +141,10 @@ ppType' ctx verbose t =
            (_, Nothing) ->
              T.empty
 
-    TArrow a b ->
+    Type (TArrowF a b) ->
       "(" <> ppType a <> " -> " <> ppType b <> ")"
 
-    TList ty ->
+    Type (TListF ty) ->
       "[" <> ppType ty <> "]"
 
 ppConstructors :: Ground l => [(Constructor, [Type l])] -> Text

--- a/projector-core/src/Projector/Core/Type.hs
+++ b/projector-core/src/Projector/Core/Type.hs
@@ -4,9 +4,21 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Projector.Core.Type (
+  -- * Types
+  -- ** Interface
     Type (..)
+  , pattern TLit
+  , pattern TVar
+  , pattern TArrow
+  , pattern TList
+  -- *** Type functor
+  , TypeF (..)
+  -- ** Declared types
   , Decl (..)
   , Ground (..)
   , TypeName (..)
@@ -25,17 +37,31 @@ import           P
 
 
 -- | Types.
-data Type l
-  = TLit l
-  | TVar TypeName
-  | TArrow (Type l) (Type l)
-  | TList (Type l)
-  deriving (Eq, Ord, Show, Read, Functor, Foldable, Traversable)
+newtype Type l = Type (TypeF l (Type l))
+  deriving (Eq, Ord, Show)
+
+pattern TLit l = Type (TLitF l)
+pattern TVar x = Type (TVarF x)
+pattern TArrow a b = Type (TArrowF a b)
+pattern TList a = Type (TListF a)
+
+-- | Type functor.
+data TypeF l a
+  = TLitF l
+  | TVarF TypeName
+  | TArrowF a a
+  | TListF a
+  deriving (Functor, Foldable, Traversable)
+
+deriving instance (Eq l, Eq a) => Eq (TypeF l a)
+deriving instance (Ord l, Ord a) => Ord (TypeF l a)
+deriving instance (Show l, Show a) => Show (TypeF l a)
+
 
 -- | Declared types.
 data Decl l
   = DVariant [(Constructor, [Type l])]
-  deriving (Eq, Ord, Show, Read, Functor, Foldable, Traversable)
+  deriving (Eq, Ord, Show)
 
 -- | The class of user-supplied primitive types.
 class (Eq l, Ord l) => Ground l where
@@ -46,15 +72,15 @@ class (Eq l, Ord l) => Ground l where
 
 -- | A type's name.
 newtype TypeName = TypeName { unTypeName :: Text }
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show)
 
 -- | A constructor's name.
 newtype Constructor  = Constructor { unConName :: Text }
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show)
 
 -- | Type contexts.
 newtype TypeDecls l = TypeDecls { unTypeDecls :: Map TypeName (Decl l) }
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show)
 
 instance Ord l => Monoid (TypeDecls l) where
   mempty = TypeDecls mempty

--- a/projector-core/test/Test/Projector/Core/Simplify.hs
+++ b/projector-core/test/Test/Projector/Core/Simplify.hs
@@ -12,7 +12,7 @@ import           P
 
 import           Projector.Core.Simplify (alphaNf, alpha, nf, whnf)
 import           Projector.Core.Syntax (Expr (..), lam_, var_, app)
-import           Projector.Core.Type (Type(..))
+import           Projector.Core.Type
 
 import           Test.Projector.Core.Arbitrary
 

--- a/projector-html/src/Projector/Html/Backend/Haskell.hs
+++ b/projector-html/src/Projector/Html/Backend/Haskell.hs
@@ -109,18 +109,18 @@ genCon (Constructor n) ts =
 
 -- | Types.
 genType :: HtmlType -> TH.Type
-genType ty =
+genType (Type ty) =
   case ty of
-    TLit l ->
+    TLitF l ->
       conT (mkName_ (ppGroundType l))
 
-    TVar (TypeName n) ->
+    TVarF (TypeName n) ->
       conT (mkName_ n)
 
-    TArrow t1 t2 ->
+    TArrowF t1 t2 ->
       arrowT_ (genType t1) (genType t2)
 
-    TList t ->
+    TListF t ->
       listT_ (genType t)
 
 -- | Expressions.

--- a/projector-html/src/Projector/Html/Backend/Purescript.hs
+++ b/projector-html/src/Projector/Html/Backend/Purescript.hs
@@ -86,16 +86,16 @@ genCon (Constructor c) ts =
 genType :: HtmlType -> Doc a
 genType ty =
   case ty of
-    TLit l ->
+    Type (TLitF l) ->
       text (ppGroundType l)
 
-    TVar (TypeName n) ->
+    Type (TVarF (TypeName n)) ->
       text n
 
-    TArrow t1 t2 ->
+    Type (TArrowF t1 t2) ->
       WL.parens (genType t1 <+> text "->" <+> genType t2)
 
-    TList t ->
+    Type (TListF t)->
       WL.parens (text "Array" <+> genType t)
 
 genTypeSig :: Name -> HtmlType -> Doc a


### PR DESCRIPTION
Adds `TypeF`, the Functor edition of `Type`, and replaces `Type` with a fixpoint of `TypeF`.

I need this for my unification solver.

In particular I want my unification variables to be distinct from my actual type variables, such that no lingering `a1` `f0`-style types can possibly remain after unification is complete.

It also means I can clearly say a fresh variable is less general than a concrete type name (because I can tell the difference between fresh variables and known ones structurally) - see https://github.com/ambiata/projector/commit/46c67f4ec9d78931cf527ed85d4552b62e90720e#diff-be8398efe3d9c5439578a982c21de7a8R286

This means recursively extending `TypeF` with an extra constructor, like so:

```haskell
newtype I l = I (Either Int (TypeF l (I l)))

pattern Dunno i = I (Left i)
pattern Its ty = I (Right ty)

freshI :: State NameSupply (I l)
freshI = do
  v <- gets varId
  modify' $ \s -> s { varId = v + 1 }
  return (Dunno v)

hoistI :: Type l -> I l
hoistI (Type ty) =
  I (Right (fmap hoistI ty))
```

disclaimer: I haven't thought much about how this interacts with type schemes once I add them, should probably work it through before pushing. seems like it'd be fine though, I could convert dangling Lefts into regular quantified variables at the end (think of the type of `const`)