### PR TITLE
Run tests against the purescript runtime

### DIFF
--- a/projector-html/bin/ci
+++ b/projector-html/bin/ci
@@ -11,5 +11,6 @@ else
 fi
 
 # TODO add npm-path once it's a thing
+cd test/purescript && npm install && npm run -s build && cd ../..
 
 master build haskell

--- a/projector-html/src/Projector/Html/Backend/Haskell.hs
+++ b/projector-html/src/Projector/Html/Backend/Haskell.hs
@@ -76,7 +76,7 @@ genModule (Module ts _ es) =
 
 genFileName :: ModuleName -> FilePath
 genFileName (ModuleName n) =
-  T.unpack (T.replace "." "/" n)
+  T.unpack (T.replace "." "/" n) <> ".hs"
 
 -- -----------------------------------------------------------------------------
 

--- a/projector-html/src/Projector/Html/Backend/Purescript.hs
+++ b/projector-html/src/Projector/Html/Backend/Purescript.hs
@@ -60,7 +60,7 @@ genImport (ModuleName n) imports =
 
 genFileName :: ModuleName -> FilePath
 genFileName (ModuleName n) =
-  T.unpack (T.replace "." "/" n)
+  T.unpack (T.replace "." "/" n) <> ".purs"
 
 -- -----------------------------------------------------------------------------
 

--- a/projector-html/test/Test/IO/Projector/Html/Backend/Property.hs
+++ b/projector-html/test/Test/IO/Projector/Html/Backend/Property.hs
@@ -16,9 +16,9 @@ import           Projector.Core
 import qualified Projector.Html.Core.Prim as Prim
 import qualified Projector.Html.Core.Library as Lib
 
-import           System.Directory (createDirectoryIfMissing)
+import           System.Directory (createDirectoryIfMissing, makeAbsolute)
 import           System.Exit (ExitCode(..))
-import           System.FilePath.Posix ((</>), (<.>), takeDirectory)
+import           System.FilePath.Posix ((</>), takeDirectory)
 import           System.IO (FilePath, IO)
 import           System.IO.Temp (withTempDirectory)
 
@@ -39,11 +39,12 @@ processProp f (code, out, err) =
 fileProp :: FilePath -> Text -> (FilePath -> IO a) -> (a -> Property) -> Property
 fileProp mname modl f g =
   testIO . withTempDirectory "./dist/" "gen-XXXXXX" $ \tmpDir -> do
-    let path = tmpDir </> mname <.> "hs"
+    let path = tmpDir </> mname
         dir = takeDirectory path
     createDirectoryIfMissing True dir
     T.writeFile path modl
-    fmap g (f path)
+    path' <- makeAbsolute path
+    fmap g (f path')
 
 
 helloWorld :: (Name, (Prim.HtmlType, Prim.HtmlExpr ()))

--- a/projector-html/test/purescript/bower.json
+++ b/projector-html/test/purescript/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "purescript-projector-html-testsuite",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "output"
+  ],
+  "dependencies": {
+    "purescript-projector-html-runtime": "../../../projector-html-runtime-purs"
+  },
+  "devDependencies": {
+    "purescript-psci-support": "^1.0.0"
+  }
+}

--- a/projector-html/test/purescript/package.json
+++ b/projector-html/test/purescript/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "purescript-projector-html-testsuite",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Purescript testsuite for projector-html",
+  "repository": "https://github.com/ambiata/projector",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "build": "psa --censor-lib --censor-codes=ShadowedName,UnusedImport --strict 'bower_components/purescript-*/src/**/*.purs'",
+    "postinstall": "bower install"
+  },
+  "author": "Ambiata <info@ambiata.com>",
+  "license": "AllRightsReserved",
+  "devDependencies": {
+    "bower": "^1.7.9",
+    "purescript-psa": "^0.4.0"
+  }
+}

--- a/projector-html/test/test-io.hs
+++ b/projector-html/test/test-io.hs
@@ -4,8 +4,8 @@ import qualified Test.IO.Projector.Html.Backend.Haskell as Haskell
 import qualified Test.IO.Projector.Html.Backend.Purescript as Purescript
 
 main :: IO ()
-main =
+main = do
   disorderMain [
-      Haskell.tests
-    , Purescript.tests
+      Purescript.tests
+    , Haskell.tests
     ]


### PR DESCRIPTION
Finagle all the npm dependencies for the purescript runtime, then use `psa` to compile the lot.

! @charleso @damncabbage @jystic 