### PR TITLE
Restore pattern annotations

### DIFF
--- a/projector-core/src/Projector/Core/Pretty.hs
+++ b/projector-core/src/Projector/Core/Pretty.hs
@@ -209,13 +209,13 @@ ppExpr' types e =
       WL.annotate a $ WL.parens (text n WL.<> text "#" WL.<> text (typeMay ty))
   where typeMay t = if types then " : " <> ppType t else T.empty
 
-ppPattern :: Pattern -> Text
+ppPattern :: Pattern a -> Text
 ppPattern p =
   case p of
-    PVar (Name n) ->
+    PVar _ (Name n) ->
       n
 
-    PCon (Constructor c) ps ->
+    PCon _ (Constructor c) ps ->
       c <> " " <> T.unwords (fmap (parenMay . ppPattern) ps)
 
 hasSpace :: Text -> Bool

--- a/projector-core/src/Projector/Core/Simplify.hs
+++ b/projector-core/src/Projector/Core/Simplify.hs
@@ -149,14 +149,14 @@ nf' ctx expr =
     expr
 
 -- | Pattern matching. Returns 'Nothing' if no match is possible.
-match :: Map Name (Expr l a) -> Pattern -> Expr l a -> Maybe (Map Name (Expr l a))
+match :: Map Name (Expr l a) -> Pattern a -> Expr l a -> Maybe (Map Name (Expr l a))
 match ctx pat expr =
   case (pat, expr) of
-    (PVar n, e) ->
+    (PVar _ n, e) ->
       -- Variable patterns always succeed.
       pure (M.insert n e ctx)
 
-    (PCon c1 ps, ECon _ c2 _ es) ->
+    (PCon _ c1 ps, ECon _ c2 _ es) ->
       -- Constructor names and arity have to match.
       if (c1 == c2) && (length ps == length es)
         then foldM (\ctx' (p, e) -> match ctx' p e) ctx (L.zip ps es)
@@ -220,16 +220,16 @@ alpha' rebinds rename expr =
     EForeign _ _ _ ->
       pure expr
 
-alphaPat' :: Map Name Name -> (Name -> Name) -> Pattern -> State (Map Name Int) (Pattern, Map Name Name)
+alphaPat' :: Map Name Name -> (Name -> Name) -> Pattern a -> State (Map Name Int) (Pattern a, Map Name Name)
 alphaPat' rebinds rename p =
   case p of
-    PVar x -> do
+    PVar a x -> do
       new <- freshen (rename x)
-      pure (PVar new, M.insert x new rebinds)
+      pure (PVar a new, M.insert x new rebinds)
 
-    PCon c pats -> do
+    PCon a c pats -> do
       (pats', rebinds') <- foldM (accum rename) ([], rebinds) pats
-      pure (PCon c (L.reverse pats'), rebinds')
+      pure (PCon a c (L.reverse pats'), rebinds')
 
   where
     accum rename' (acc, rebinds') p2 = do

--- a/projector-core/test/Test/Projector/Core/Arbitrary.hs
+++ b/projector-core/test/Test/Projector/Core/Arbitrary.hs
@@ -117,13 +117,13 @@ genCon t v =
     <*> t
     <*> listOf v
 
-genCase :: Jack (Expr l ()) -> Jack Pattern -> Jack (Expr l ())
+genCase :: Jack (Expr l ()) -> Jack (Pattern ()) -> Jack (Expr l ())
 genCase e p =
   case_
     <$> e
     <*> (fmap NE.toList (listOf1 $ (,) <$> p <*> e))
 
-genPattern :: Jack Constructor -> Jack Name -> Jack Pattern
+genPattern :: Jack Constructor -> Jack Name -> Jack (Pattern ())
 genPattern c n =
   oneOfRec [fmap pvar n] [pcon <$> c <*> listOf (genPattern c n)]
 
@@ -375,7 +375,7 @@ genAlternatives ::
   -> (Context l -> Type l -> Jack (Expr l ()))
   -> [(Constructor, [Type l])]
   -> Type l
-  -> Jack [(Pattern, Expr l ())]
+  -> Jack [(Pattern (), Expr l ())]
 genAlternatives ctx names more cts want =
   for cts $ \(c, tys) -> do
     let bnds = L.take (length tys) (freshNames "x")

--- a/projector-html/src/Projector/Html/Backend/Haskell.hs
+++ b/projector-html/src/Projector/Html/Backend/Haskell.hs
@@ -152,17 +152,17 @@ genExp expr =
       varE (mkName_ x)
 
 -- | Case alternatives.
-genMatch :: Pattern -> HtmlExpr a -> TH.Match
+genMatch :: Pattern a -> HtmlExpr a -> TH.Match
 genMatch p e =
   match_ (genPat p) (genExp e)
 
 -- | Patterns.
-genPat :: Pattern -> TH.Pat
+genPat :: Pattern a -> TH.Pat
 genPat p = case p of
-  PVar (Name n) ->
+  PVar _ (Name n) ->
     varP (mkName_ n)
 
-  PCon (Constructor n) ps ->
+  PCon _ (Constructor n) ps ->
     conP (mkName_ n) (fmap genPat ps)
 
 -- | Literals.

--- a/projector-html/src/Projector/Html/Backend/Purescript.hs
+++ b/projector-html/src/Projector/Html/Backend/Purescript.hs
@@ -139,17 +139,17 @@ genExp expr =
     EForeign a (Name n) _ ->
       WL.annotate a (text n)
 
-genMatch :: Pattern -> HtmlExpr a -> Doc a
+genMatch :: Pattern a -> HtmlExpr a -> Doc a
 genMatch p e =
   WL.hang 2 ((genPat p WL.<> text " ->") <$$> genExp e)
 
-genPat :: Pattern -> Doc a
+genPat :: Pattern a -> Doc a
 genPat p =
   case p of
-    PVar (Name n) ->
-      text n
-    PCon (Constructor n) ps ->
-      WL.parens (text n <+> WL.hsep (fmap genPat ps))
+    PVar a (Name n) ->
+      WL.annotate a (text n)
+    PCon a (Constructor n) ps ->
+      WL.annotate a (WL.parens (text n <+> WL.hsep (fmap genPat ps)))
 
 genLit :: Value PrimT -> Doc a
 genLit v =

--- a/projector-html/src/Projector/Html/Core/Elaborator.hs
+++ b/projector-html/src/Projector/Html/Core/Elaborator.hs
@@ -107,18 +107,18 @@ eExpr expr =
     TECase a e alts ->
       ECase a (eExpr e) (NE.toList (fmap eAlt alts))
 
-eAlt :: TAlt a -> (Pattern, HtmlExpr a)
+eAlt :: TAlt a -> (Pattern a, HtmlExpr a)
 eAlt (TAlt _ pat body) =
   (ePat pat, eAltBody body)
 
-ePat :: TPattern a -> Pattern
+ePat :: TPattern a -> Pattern a
 ePat pat =
   -- TODO find something we can do with these annotations
   case pat of
-    TPVar _ (TId x) ->
-      PVar (Name x)
-    TPCon _ (TConstructor x) pats ->
-      PCon (Constructor x) (fmap ePat pats)
+    TPVar a (TId x) ->
+      PVar a (Name x)
+    TPCon a (TConstructor x) pats ->
+      PCon a (Constructor x) (fmap ePat pats)
 
 eAltBody :: TAltBody a -> HtmlExpr a
 eAltBody body =


### PR DESCRIPTION
I removed these in anger a while back, because I was getting annoyed making the `Expr a` line up with the `Pattern a`, especially as I was smuggling type information in the `a`. Patterns don't even have types!

Turns out I need the source locations to produce Lennart-style annotated types in my new typechecker. Patterns introduce new constraints, in fact they're our most common source of constraints, and we really want to track their provenance properly ("Type introduced in pattern at L101-C42").

I will likely end up adding a function like

```haskell
extendExpr :: Expr l a -> (Expr l a -> b) -> (Pattern a -> b) -> Expr l b
```

... and then turn `a` into 

```
data Ann a = EAnn a | EPat a
```

... so that we can properly separate the two classes of annotation.

! @jystic @charleso 