### PR TITLE
Get rid of UndecidableInstances

### DIFF
--- a/projector-core/src/Projector/Core/Check.hs
+++ b/projector-core/src/Projector/Core/Check.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE UndecidableInstances #-}
 module Projector.Core.Check (
   -- * Interface
     TypeError (..)
@@ -56,9 +54,9 @@ data TypeError l a
   | InferenceError a
   | InfiniteType (Type l, a) (Type l, a)
 
-deriving instance (Eq l, Eq (Value l), Eq a) => Eq (TypeError l a)
-deriving instance (Show l, Show (Value l), Show a) => Show (TypeError l a)
-deriving instance (Ord l, Ord (Value l), Ord a) => Ord (TypeError l a)
+deriving instance (Ground l, Eq a) => Eq (TypeError l a)
+deriving instance (Ground l, Show a) => Show (TypeError l a)
+deriving instance (Ground l, Ord a) => Ord (TypeError l a)
 
 
 -- | Typecheck an interdependent set of named expressions.

--- a/projector-core/src/Projector/Core/Syntax.hs
+++ b/projector-core/src/Projector/Core/Syntax.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE UndecidableInstances #-}
 module Projector.Core.Syntax (
     Expr (..)
   , extractAnnotation
@@ -64,9 +63,9 @@ data Expr l a
   | EForeign a Name (Type l)
   deriving (Functor, Foldable, Traversable)
 
-deriving instance (Eq l, Eq (Value l), Eq a) => Eq (Expr l a)
-deriving instance (Show l, Show (Value l), Show a) => Show (Expr l a)
-deriving instance (Ord l, Ord (Value l), Ord a) => Ord (Expr l a)
+deriving instance (Ground l, Eq a) => Eq (Expr l a)
+deriving instance (Ground l, Show a) => Show (Expr l a)
+deriving instance (Ground l, Ord a) => Ord (Expr l a)
 
 extractAnnotation :: Expr l a -> a
 extractAnnotation e =

--- a/projector-core/src/Projector/Core/Type.hs
+++ b/projector-core/src/Projector/Core/Type.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
 module Projector.Core.Type (
   -- * Types
   -- ** Interface
@@ -65,7 +65,7 @@ data Decl l
   deriving (Eq, Ord, Show)
 
 -- | The class of user-supplied primitive types.
-class (Eq l, Ord l) => Ground l where
+class (Eq l, Ord l, Show l, Eq (Value l), Ord (Value l), Show (Value l)) => Ground l where
   data Value l
   typeOf :: Value l -> l
   ppGroundType :: l -> Text

--- a/projector-core/test/bench.hs
+++ b/projector-core/test/bench.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 


### PR DESCRIPTION
The syntax seems unintuitive to me, but apparently this is how you put constraints on an associated typeclass.

We still need StandaloneDeriving for some reason. It can't figure out the `Ground l` constraint from the use of `Value l`. Maybe GHC 8 will do better...

! @tmcgilchrist @jystic @charleso 