### PR TITLE
Swappable ground types

### DIFF
--- a/projector-core/src/Projector/Core/Type.hs
+++ b/projector-core/src/Projector/Core/Type.hs
@@ -16,6 +16,7 @@ module Projector.Core.Type (
   , pattern TVar
   , pattern TArrow
   , pattern TList
+  , mapGroundType
   -- *** Type functor
   , TypeF (..)
   -- ** Declared types
@@ -58,6 +59,21 @@ deriving instance (Eq l, Eq a) => Eq (TypeF l a)
 deriving instance (Ord l, Ord a) => Ord (TypeF l a)
 deriving instance (Show l, Show a) => Show (TypeF l a)
 
+-- | Swap out the ground type.
+mapGroundType :: Ground l => Ground m => (l -> m) -> Type l -> Type m
+mapGroundType tmap (Type ty) =
+  Type $ case ty of
+    TLitF l ->
+      TLitF (tmap l)
+
+    TVarF tn ->
+      TVarF tn
+
+    TArrowF a b ->
+      TArrowF (mapGroundType tmap a) (mapGroundType tmap b)
+
+    TListF a ->
+      TListF (mapGroundType tmap a)
 
 -- | Declared types.
 data Decl l


### PR DESCRIPTION
Currently we're riding on every library type having something with the same name and same semantics in the target platform. This is something we need to eliminate.

I plan on using rewrite rules in #68 to change the semantics for declared types, and this `mapGround` function for primitive types.

We could just render the original set of primitives in different ways on different platforms, but this lets us separate the rewritten trees as `Expr HaskellPrim a` and `Expr PuxPrim a`. I figure this type distinction is useful. It's a lazy traversal, so the cost is a slight constant factor.

! @jystic @charleso 
/jury approve @charleso @ambiata-ci