### PR TITLE
Add nested HTML to domain model

### DIFF
--- a/projector-html/src/Projector/Html/Backend/Haskell/Rewrite.hs
+++ b/projector-html/src/Projector/Html/Backend/Haskell/Rewrite.hs
@@ -28,6 +28,10 @@ rewriteExpr =
 -- TODO these rules can operate on the fully typed AST if we need it
 -- TODO oh god, this all goes to hell if people shadow the runtime names
 --      (we better make this hard or illegal)
+
+-- * Erase all evidence of the HtmlNode type, which doesn't exist at runtime.
+--   Each gets converted to Hydrant's Html type.
+-- * Projector's HTML type becomes a monoidal fold of Hydrant's Html type.
 rules :: [RewriteRule PrimT a]
 rules =
   fmap Rewrite [
@@ -49,6 +53,10 @@ rules =
                empty)
     , (\case ECon a (Constructor "Comment") _ [str] ->
                pure (apply (comment a) [str])
+             _ ->
+               empty)
+    , (\case ECon _ (Constructor "Nested") _ [html] ->
+               pure html
              _ ->
                empty)
     , (\case ECon a (Constructor "Html") _ [nodes] ->

--- a/projector-html/src/Projector/Html/Core/Elaborator.hs
+++ b/projector-html/src/Projector/Html/Core/Elaborator.hs
@@ -58,8 +58,10 @@ eNode node =
         , eAttrs a attrs
         , eHtml html
         ]
-    TExprNode _ expr ->
-      eExpr expr
+    TExprNode a expr ->
+      ECon a (Constructor "Nested") Lib.nHtmlNode [
+          eExpr expr
+        ]
 
 eTag :: TTag a -> HtmlExpr a
 eTag (TTag a t) =

--- a/projector-html/src/Projector/Html/Core/Library.hs
+++ b/projector-html/src/Projector/Html/Core/Library.hs
@@ -139,4 +139,5 @@ dHtmlNode =
     , (Constructor "Comment", [TLit TString])
     , (Constructor "Plain", [TLit TString])
     , (Constructor "Whitespace", [])
+    , (Constructor "Nested", [tHtml])
     ]


### PR DESCRIPTION
On #70  (Just one commit, https://github.com/ambiata/projector/commit/b307233937464fe97a07765ce873b4ca9f63ccc9)

This introduces a new constructor, `Nested :: Html -> HtmlNode`, to the logical Html model.

`Nested` is introduced silently by the elaborator and erased using rewrite rules. It should be impossible to use incorrectly. Users will deal with the `Html` type only, never seeing `HtmlNode`.

It allows partials to work properly. The following did not work before:

```
\ foo : Html ->
<blink>{ foo }</blink>
```

Each backend is likely to have a different strategy to deal with nested Html structures. The change for the Hydrant backend is pretty trivial, because `Html` is a monoid and `HtmlNode` doesn't exist at runtime; we just unbox it. The Pux implementation will end up being quite annoying, likely with array concatenation.

! @charleso @jystic 

Closes #64 