### PR TITLE
Type inference

### DIFF
--- a/projector-core/src/Projector/Core/Pretty.hs
+++ b/projector-core/src/Projector/Core/Pretty.hs
@@ -161,10 +161,10 @@ ppExpr' types e =
           gg = ppExpr' types g
       in WL.annotate a (WL.hang 2 (WL.parens (ff </> gg)))
 
-    ELam a (Name n) t f ->
+    ELam a (Name n) mt f ->
       WL.annotate a $
         WL.hang 2
-              ((text ("\\" <> n <> typeMay t <> "."))
+              ((text ("\\" <> n <> maybe mempty typeMay mt <> "."))
           <$$> (ppExpr' types f))
 
     ECon a (Constructor c) _ es ->

--- a/projector-core/src/Projector/Core/Syntax.hs
+++ b/projector-core/src/Projector/Core/Syntax.hs
@@ -17,6 +17,7 @@ module Projector.Core.Syntax (
   , lit
   , lam
   , lam_
+  , lam__
   , var
   , var_
   , app
@@ -65,7 +66,7 @@ import           Projector.Core.Type
 data Expr l a
   = ELit a (Value l)
   | EVar a Name
-  | ELam a Name (Type l) (Expr l a)
+  | ELam a Name (Maybe (Type l)) (Expr l a)
   | EApp a (Expr l a) (Expr l a)
   | ECon a Constructor TypeName [Expr l a]
   | ECase a (Expr l a) [(Pattern a, Expr l a)]
@@ -121,13 +122,17 @@ lit :: Value l -> Expr l ()
 lit =
   ELit ()
 
-lam :: Name -> Type l -> Expr l () -> Expr l ()
+lam :: Name -> Maybe (Type l) -> Expr l () -> Expr l ()
 lam =
   ELam ()
 
-lam_ :: Text -> Type l -> Expr l () -> Expr l ()
+lam_ :: Text -> Maybe (Type l) -> Expr l () -> Expr l ()
 lam_ n =
   lam (Name n)
+
+lam__ :: Text -> Expr l () -> Expr l ()
+lam__ n =
+  lam_ n Nothing
 
 var :: Name -> Expr l ()
 var =
@@ -250,7 +255,7 @@ mapGround tmap vmap expr =
       EVar a n
 
     ELam a n t e ->
-      ELam a n (mapGroundType tmap t) (mapGround tmap vmap e)
+      ELam a n (fmap (mapGroundType tmap) t) (mapGround tmap vmap e)
 
     EApp a f g ->
       EApp a (mapGround tmap vmap f) (mapGround tmap vmap g)

--- a/projector-core/test/Test/Projector/Core/Simplify.hs
+++ b/projector-core/test/Test/Projector/Core/Simplify.hs
@@ -61,23 +61,23 @@ church =
 
 zero :: Expr TestLitT ()
 zero =
-  lam_ "f" (TArrow unit unit)
-    (lam_ "x" unit (var_ "x"))
+  lam_ "f" (Just (TArrow unit unit))
+    (lam_ "x" (Just unit) (var_ "x"))
 
 succ :: Expr TestLitT ()
 succ =
-  lam_ "n" church
-    (lam_ "f" (TArrow unit unit)
-      (lam_ "x" unit
+  lam_ "n" (Just church)
+    (lam_ "f" (Just (TArrow unit unit))
+      (lam_ "x" (Just unit)
         (app
           (var_ "f")
           (app (app (var_ "n") (var_ "f")) (var_ "x")))))
 
 mult :: Expr TestLitT ()
 mult =
-  lam_ "m" church
-    (lam_ "n" church
-      (lam_ "f" (TArrow unit unit)
+  lam_ "m" (Just church)
+    (lam_ "n" (Just church)
+      (lam_ "f" (Just (TArrow unit unit))
         (app
           (var_ "m")
           (app (var_ "n") (var_ "f")))))

--- a/projector-core/test/bench.hs
+++ b/projector-core/test/bench.hs
@@ -24,7 +24,7 @@ import           Test.Projector.Core.Simplify (mul, nth)
 buildExpr :: Int -> Expr TestLitT ()
 buildExpr n = case n of
   0 -> var_ "billy"
-  m -> app (lam_ "billy" (TLit TBool) (buildExpr (m - 1))) (lit (VBool True))
+  m -> app (lam_ "billy" (Just (TLit TBool)) (buildExpr (m - 1))) (lit (VBool True))
 
 -- big case
 

--- a/projector-html/src/Projector/Html/Core/Elaborator.hs
+++ b/projector-html/src/Projector/Html/Core/Elaborator.hs
@@ -22,7 +22,7 @@ elaborate (Template _ mts html) =
 eTypeSigs :: Maybe (TTypeSig a) -> (HtmlExpr a -> HtmlExpr a)
 eTypeSigs msigs =
   mcase msigs id $ \(TTypeSig a sigs) ->
-    foldl' (\f (TId x, ty) -> f . ELam a (Name x) (eType ty)) id sigs
+    foldl' (\f (TId x, ty) -> f . ELam a (Name x) (Just (eType ty))) id sigs
 
 eType :: TType a -> HtmlType
 eType ty =


### PR DESCRIPTION
(sorta)

Infers the parameters for lambdas. Without polymorphism, this means the lambda has to be applied to something, else we can't infer anything about it. i.e. there's no such type as `a -> Bool` or `a -> a`, so if that's your type, bad luck.

While this sounds like it is only mildly useful, it's all we need for `projector-html` to grow list iteration / lambda syntax.

```
λ> typeTree mempty $ (lam__ "foo" (var_ "foo") :: Expr TestLitT ())
Left [InferenceError (),InferenceError ()]
λ> typeTree mempty $ (app (lam__ "foo" (var_ "foo") :: Expr TestLitT ()) (lit (VBool True)))
Right (EApp (Type (TLitF TBool),()) (ELam (Type (TArrowF (Type (TLitF TBool)) (Type (TLitF TBool))),()) (Name {unName = "foo"}) Nothing (EVar (Type (TLitF TBool),()) (Name {unName = "foo"}))) (ELit (Type (TLitF TBool),()) (VBool True)))
```

! @charleso @jystic 