### PR TITLE
Lambda template syntax

### DIFF
--- a/projector-html/src/Projector/Html/Core/Elaborator.hs
+++ b/projector-html/src/Projector/Html/Core/Elaborator.hs
@@ -5,6 +5,7 @@ module Projector.Html.Core.Elaborator (
   ) where
 
 
+import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 
 import           P
@@ -104,10 +105,17 @@ eExpr expr =
   case expr of
     TEVar a (TId x) ->
       EVar a (Name x)
+    TELam a bnds bdy ->
+      funX a (fmap (Name . unTId) bnds) (eExpr bdy)
     TEApp a f g ->
       EApp a (eExpr f) (eExpr g)
     TECase a e alts ->
       ECase a (eExpr e) (NE.toList (fmap eAlt alts))
+
+-- curried function
+funX :: a -> NonEmpty Name -> HtmlExpr a -> HtmlExpr a
+funX a bnds bdy =
+  foldr (\n expr -> ELam a n Nothing expr) bdy bnds
 
 eAlt :: TAlt a -> (Pattern a, HtmlExpr a)
 eAlt (TAlt _ pat body) =

--- a/projector-html/src/Projector/Html/Data/Position.hs
+++ b/projector-html/src/Projector/Html/Data/Position.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -55,7 +57,7 @@ instance Monoid Range where
 -- | A functor for positioned tokens.
 data Positioned a
   = !a :@ !Range
-  deriving (Eq, Ord, Show, Data, Typeable, Generic, Functor)
+  deriving (Eq, Ord, Show, Data, Typeable, Generic, Functor, Foldable, Traversable)
 
 extractPositioned :: Positioned a -> a
 extractPositioned (a :@ _) =

--- a/projector-html/src/Projector/Html/Data/Template.hs
+++ b/projector-html/src/Projector/Html/Data/Template.hs
@@ -177,6 +177,7 @@ instance Comonad TAttrValue where
 
 data TExpr a
   = TEVar a TId
+  | TELam a (NonEmpty TId) (TExpr a)
   | TEApp a (TExpr a) (TExpr a)
   | TECase a (TExpr a) (NonEmpty (TAlt a))
   deriving (Eq, Ord, Show, Data, Typeable, Generic, Functor, Foldable, Traversable)
@@ -186,6 +187,8 @@ instance Comonad TExpr where
     case expr of
       TEVar a _ ->
         a
+      TELam a _ _ ->
+        a
       TEApp a _ _ ->
         a
       TECase a _ _ ->
@@ -194,6 +197,8 @@ instance Comonad TExpr where
     case expr of
       TEVar _ a ->
         TEVar (f expr) a
+      TELam _ ids e ->
+        TELam (f expr) ids (extend f e)
       TEApp _ e1 e2 ->
         TEApp (f expr) (extend f e1) (extend f e2)
       TECase _ e alts ->

--- a/projector-html/src/Projector/Html/Data/Token.hs
+++ b/projector-html/src/Projector/Html/Data/Token.hs
@@ -47,6 +47,8 @@ data Token
   | CaseOf          -- of
   | CaseSep         -- ;
   | AltSep          -- ->
+  | LamStart        -- \
+  | LamBody         -- ->
   -- Patterns
   | PatCon Text     -- Just
   | PatId Text      -- x
@@ -91,6 +93,8 @@ renderToken tok =
     CaseOf          -> "of"
     CaseSep         -> ";"
     AltSep          -> "->"
+    LamStart        -> "\\"
+    LamBody         -> "->"
 
     PatCon t        -> t
     PatId t         -> t

--- a/projector-html/src/Projector/Html/Pretty.hs
+++ b/projector-html/src/Projector/Html/Pretty.hs
@@ -53,6 +53,8 @@ uglyPrintTemplate =
           " "
         AltSep ->
           " "
+        LamBody ->
+          " "
         PatId _ ->
           " "
         PatLParen ->
@@ -66,6 +68,8 @@ uglyPrintTemplate =
         TypeSigsSep ->
           "\n"
         ExprStart ->
+          " "
+        LamStart ->
           " "
         _ ->
           mempty
@@ -197,6 +201,14 @@ exprTokens expr =
   case expr of
     TEVar _ (TId x) ->
       [ExprIdent x]
+    TELam _ ids e ->
+      mconcat [
+          [ExprLParen, LamStart]
+        , (fmap (\(TId x) -> ExprIdent x) (D.fromList (toList ids)))
+        , [LamBody]
+        , exprTokens e
+        , [ExprRParen]
+        ]
     TEApp _ f g ->
       mconcat [
           [ExprLParen]

--- a/projector-html/test/Test/Projector/Html/Arbitrary.hs
+++ b/projector-html/test/Test/Projector/Html/Arbitrary.hs
@@ -190,6 +190,7 @@ genTemplateExpr k =
       recc = [
           TEApp () <$> genTemplateExpr j <*> genTemplateExpr j
         , TECase () <$> genTemplateExpr j <*> genTemplateAlts j
+        , TELam () <$> (listOf1 (TId <$> elements simpsons)) <*> genTemplateExpr j
         ]
   in if k <= 2 then oneOf nonrec else oneOf recc
 


### PR DESCRIPTION
Mostly works, just has a weird ambiguity as per #80 

```
slideshow> :let foo \ str : Html -> { (\x y z -> x) str str str }
foo : (Html -> Html)
slideshow> :haskell foo
foo = \str -> foldHtml [textNode " ",
                        (\x -> \y -> \z -> x) str str str]
```