### PR TITLE
Remove type annotation from list

### DIFF
--- a/projector-core/src/Projector/Core/Check.hs
+++ b/projector-core/src/Projector/Core/Check.hs
@@ -393,13 +393,14 @@ generateConstraints' decls expr =
       addConstraint (Equal (I (Am a (TArrowF (extractType g') t))) (extractType f'))
       pure (EApp (t, a) f' g')
 
-    EList a te es -> do
+    EList a es -> do
       -- Proceed bottom-up, inferring types for each expression in the list.
       -- Constrain each type to be the annotated 'ty'.
       es' <- for es (generateConstraints' decls)
-      for_ es' (addConstraint . Equal (hoistType a te) . extractType)
-      let ty = I (Am a (TListF (hoistType a te)))
-      pure (EList (ty, a) te es')
+      te <- freshTypeVar a
+      for_ es' (addConstraint . Equal te . extractType)
+      let ty = I (Am a (TListF te))
+      pure (EList (ty, a) es')
 
     EMap a f g -> do
       -- Special case polymorphic map. g must be List a, f must be (a -> b)

--- a/projector-core/src/Projector/Core/Pretty.hs
+++ b/projector-core/src/Projector/Core/Pretty.hs
@@ -187,7 +187,7 @@ ppExpr' types e =
                      (WL.hang 2 ((text (ppPattern p) <+> text "->") </> ppExpr' types g))
                  </> (doc WL.<> text ";")) WL.empty bs))
 
-    EList a _ es ->
+    EList a es ->
       WL.annotate a $ WL.hang 2 (WL.list (fmap (ppExpr' types) es))
 
     EMap a f g ->

--- a/projector-core/src/Projector/Core/Rewrite.hs
+++ b/projector-core/src/Projector/Core/Rewrite.hs
@@ -67,9 +67,9 @@ rewriteT rules expr =
       e' <- rewriteT rules e
       pes' <- for pes (\(p, ex) -> fmap (p,) (rewriteT rules ex))
       applyRules (ECase a e' pes') rules
-    EList a t es -> do
+    EList a es -> do
       es' <- traverse (rewriteT rules) es
-      applyRules (EList a t es') rules
+      applyRules (EList a es') rules
     EMap a e1 e2 -> do
       e1' <- rewriteT rules e1
       e2' <- rewriteT rules e2

--- a/projector-core/test/Test/Projector/Core/Arbitrary.hs
+++ b/projector-core/test/Test/Projector/Core/Arbitrary.hs
@@ -79,7 +79,7 @@ genExpr n t v =
         ECase _ e pes ->
           e : fmap snd pes
 
-        EList _ _ es ->
+        EList _ es ->
           es
 
         EMap _ f g ->
@@ -99,7 +99,7 @@ genExpr n t v =
         , genLam n t v
         , genCon (fmap (TypeName . unName) n) (genExpr n t v)
         , genCase (genExpr n t v) (genPattern genConstructor n)
-        , list <$> t <*> listOf (genExpr n t v)
+        , list <$> listOf (genExpr n t v)
         , EMap () <$> genExpr n t v <*> genExpr n t v
         ]
  in reshrink shrink (oneOfRec nonrec recc)
@@ -317,8 +317,8 @@ genWellTypedExpr' n ty ctx names genty genval =
           genWellTypedLam n t1 t2 ctx names genty genval
 
         Type (TListF lty) -> do
-          k <- chooseInt (0, n)
-          list lty <$> replicateM k (genWellTypedExpr' (n `div` (max 1 (n - k))) lty ctx names genty genval)
+          k <- chooseInt (1, n+1)
+          list <$> replicateM k (genWellTypedExpr' (n `div` (max 1 (n - k))) lty ctx names genty genval)
 
   -- try to look something appropriate up from the context
   in case plookup names ty of

--- a/projector-html/src/Projector/Html/Backend/Haskell.hs
+++ b/projector-html/src/Projector/Html/Backend/Haskell.hs
@@ -202,7 +202,7 @@ genExp expr =
     ECase _ e pats ->
       caseE (genExp e) (fmap (uncurry genMatch) pats)
 
-    EList _ _ es ->
+    EList _ es ->
       listE (fmap genExp es)
 
     EForeign _ (Name x) _ ->

--- a/projector-html/src/Projector/Html/Backend/Haskell/Rewrite.hs
+++ b/projector-html/src/Projector/Html/Backend/Haskell/Rewrite.hs
@@ -73,14 +73,14 @@ rules =
 
       -- These rules are just optimisations.
       -- foldHtml of a singleton: id
-    , (\case EApp _ (EForeign _ (Name "foldHtml") _) (EList _ _ [x]) ->
+    , (\case EApp _ (EForeign _ (Name "foldHtml") _) (EList _ [x]) ->
                pure x
              _ ->
                empty)
       -- adjacent raw plaintext nodes can be merged
-    , (\case EApp a fh@(EForeign _ (Name "foldHtml") _) (EList b t nodes) -> do
+    , (\case EApp a fh@(EForeign _ (Name "foldHtml") _) (EList b nodes) -> do
                nodes' <- foldRaw nodes
-               pure (EApp a fh (EList b t nodes'))
+               pure (EApp a fh (EList b nodes'))
              _ ->
                empty)
 

--- a/projector-html/src/Projector/Html/Backend/Purescript.hs
+++ b/projector-html/src/Projector/Html/Backend/Purescript.hs
@@ -155,7 +155,7 @@ genExp expr =
                       WL.empty
                       bs))))
 
-    EList a _ es ->
+    EList a es ->
       WL.annotate a (WL.hang 2 (WL.list (fmap genExp es)))
 
     EMap a f g ->

--- a/projector-html/src/Projector/Html/Backend/Rewrite.hs
+++ b/projector-html/src/Projector/Html/Backend/Rewrite.hs
@@ -18,13 +18,13 @@ globalRules :: [RewriteRule PrimT a]
 globalRules =
   fmap Rewrite [
       -- adjacent plaintext nodes - fold together
-      (\case ECon a (Constructor "Html") ty [EList b t nodes] -> do
+      (\case ECon a (Constructor "Html") ty [EList b nodes] -> do
                nodes' <- foldRaw nodes
-               pure (ECon a (Constructor "Html") ty [EList b t nodes'])
+               pure (ECon a (Constructor "Html") ty [EList b nodes'])
              _ ->
                empty)
       -- concat of a singleton - id
-    , (\case EApp _ (EForeign _ (Name "concat") _) (EList _ _ [x]) ->
+    , (\case EApp _ (EForeign _ (Name "concat") _) (EList _ [x]) ->
                pure x
              _ ->
                empty)

--- a/projector-html/src/Projector/Html/Core/Elaborator.hs
+++ b/projector-html/src/Projector/Html/Core/Elaborator.hs
@@ -43,7 +43,7 @@ eType ty =
 
 eHtml :: THtml a -> HtmlExpr (Annotation a)
 eHtml (THtml a nodes) =
-  ECon (HtmlBlock a) (Constructor "Html") Lib.nHtml [EList (SourceAnnotation a) Lib.tHtmlNode (fmap eNode nodes)]
+  ECon (HtmlBlock a) (Constructor "Html") Lib.nHtml [EList (SourceAnnotation a) (fmap eNode nodes)]
 
 eNode :: TNode a -> HtmlExpr (Annotation a)
 eNode node =
@@ -76,7 +76,7 @@ eTag (TTag a t) =
 
 eAttrs :: a -> [TAttribute a] -> HtmlExpr (Annotation a)
 eAttrs a =
-  EList (SourceAnnotation a) Lib.tAttribute . fmap eAttr
+  EList (SourceAnnotation a) . fmap eAttr
 
 eAttr :: TAttribute a -> HtmlExpr (Annotation a)
 eAttr attr =
@@ -129,7 +129,7 @@ eExpr expr =
       eStr s
     TENode a e ->
       ECon (HtmlBlock a) (Constructor "Html") Lib.nHtml [
-          EList (HtmlBlock a) Lib.tHtmlNode [eNode e]
+          EList (HtmlBlock a) [eNode e]
         ]
 
 eStr :: TIString a -> HtmlExpr (Annotation a)
@@ -138,7 +138,7 @@ eStr (TIString a chunks) =
   EApp
     (SourceAnnotation a)
     (fmap (const (LibraryFunction Prim.nStringConcat)) Prim.eStringConcat)
-    (EList (SourceAnnotation a) (TLit TString) (fmap eChunk chunks))
+    (EList (SourceAnnotation a) (fmap eChunk chunks))
 
 eChunk :: TIChunk a -> HtmlExpr (Annotation a)
 eChunk chunk =

--- a/projector-html/src/Projector/Html/Core/Library.hs
+++ b/projector-html/src/Projector/Html/Core/Library.hs
@@ -188,7 +188,7 @@ eHtmlText :: HtmlExpr ()
 eHtmlText =
   ELam () (Name "t") (Just (TLit TString))
     (ECon () (Constructor "Html") nHtml
-      [EList () tHtmlNode [ECon () (Constructor "Plain") nHtmlNode [EVar () (Name "t")]]])
+      [EList () [ECon () (Constructor "Plain") nHtmlNode [EVar () (Name "t")]]])
 
 -- -----------------------------------------------------------------------------
 
@@ -218,6 +218,6 @@ tHtmlBlank =
 eHtmlBlank :: HtmlExpr ()
 eHtmlBlank =
   con (Constructor "Html") nHtml
-    [list tHtmlNode []]
+    [list []]
 
 -- -----------------------------------------------------------------------------

--- a/projector-html/test/Test/IO/Projector/Html/Backend/Property.hs
+++ b/projector-html/test/Test/IO/Projector/Html/Backend/Property.hs
@@ -52,19 +52,19 @@ helloWorld =
   ( Name "helloWorld"
   , ( Lib.tHtml
     , con (Constructor "Html") Lib.nHtml [
-        list Lib.tHtmlNode [
+        list [
             con (Constructor "Plain") Lib.nHtmlNode [lit (Prim.VString "Hello,")]
           , con (Constructor "Whitespace") Lib.nHtmlNode []
           , con (Constructor "Nested") Lib.nHtmlNode [app (var Lib.nHtmlText) (lit (Prim.VString "world!"))]
           , con (Constructor "Element") Lib.nHtmlNode [
                 con (Constructor "Tag") Lib.nTag [lit (Prim.VString "div")]
-              , list Lib.tAttribute [
+              , list [
                     con (Constructor "Attribute") Lib.nAttribute [
                       con (Constructor "AttributeKey") Lib.nAttributeKey [lit (Prim.VString "class")]
                     , app (var Lib.nHtmlAttrValue) (lit (Prim.VString "table"))
                     ]
                   ]
-              , con (Constructor "Html") Lib.nHtml [list Lib.tHtmlNode [con (Constructor "Whitespace") Lib.nHtmlNode []]]
+              , con (Constructor "Html") Lib.nHtml [list [con (Constructor "Whitespace") Lib.nHtmlNode []]]
               ]
           , con (Constructor "Nested") Lib.nHtmlNode [var Lib.nHtmlBlank]
           ]


### PR DESCRIPTION
We don't need this type annotation on lists anymore. It's a remnant from before we had type inference, because we couldn't figure out the type of `[]`. Now we infer it.

Removing this lets me reinstate the evaluator, which we need for the loom documentation server.

! @charleso 
/jury approved @charleso