### PR TITLE
Catch bad record projections

### DIFF
--- a/projector-core/src/Projector/Core/Pretty.hs
+++ b/projector-core/src/Projector/Core/Pretty.hs
@@ -111,9 +111,6 @@ ppTypeError' err =
         WL.hang 2
           (text "Duplicate record fields for type " WL.<> WL.squotes (text tn) WL.<> text ":"
           WL.<$$> (WL.hcat (WL.punctuate WL.comma (fmap (text . unFieldName) fns))))
-    RecordUnificationError tes ->
-      WL.hang 2 $ (text "Type errors (record unification):")
-        WL.<$$> WL.vcat (fmap ppTypeError' tes)
     UndeclaredType (TypeName n) a ->
       WL.annotate a (text "Undeclared type: " WL.<> WL.squotes (text n))
     InferenceError a ->

--- a/projector-core/test/Test/Projector/Core/Check.hs
+++ b/projector-core/test/Test/Projector/Core/Check.hs
@@ -142,7 +142,7 @@ prop_record_unit_prj_extra =
   once $
     typeCheck dRecord rexpr
     ===
-    Left [ RecordUnificationError [ ExtraRecordField nRecord (FieldName "quux") (TVar (TypeName "b"), ()) () ] ]
+    Left [ ExtraRecordField nRecord (FieldName "quux") (TVar (TypeName "b"), ()) () ]
   where
     rexpr =
       EApp ()


### PR DESCRIPTION
We were getting away with these when the overall type could be inferred, leading to Haskell and interpreter errors.

! @charleso 

Closes #184 
/jury approved @charleso