### PR TITLE
Fix spurious A != A error when matching on records

### DIFF
--- a/projector-core/src/Projector/Core/Check.hs
+++ b/projector-core/src/Projector/Core/Check.hs
@@ -620,7 +620,7 @@ patternConstraints decls ty pat =
         Just (tn, ts) -> do
           unless (length ts == length pats)
             (throwError (BadPatternArity c (TVar tn) (length ts) (length pats) a))
-          let ty' = IVar a tn
+          let ty' = hoistType decls a (TVar tn)
           addConstraint (Equal ty' ty)
           pats' <- for (L.zip (fmap (hoistType decls a) ts) pats) (uncurry (patternConstraints decls))
           pure (PCon (ty', a) c pats')


### PR DESCRIPTION
Was putting the pattern's type name into an `IVar` instead of converting it to our internal representation properly. Was leading to `Bar != Bar` when the `IVar` was compared to a `IRecord`.

! @charleso 
/jury approved @charleso