### PR TITLE
Support platform constants

### DIFF
--- a/projector-cli/main/cinema.hs
+++ b/projector-cli/main/cinema.hs
@@ -132,8 +132,8 @@ cinemaBuild b mb msp tg mdg o = do
     let stripPrefix = maybe f (\sp -> makeRelative (unStripPrefix sp) f) msp
     pure (stripPrefix, body)
   -- Run the build
-  ba <- hoistEither (first BuildError (runBuild b udts rts))
-  out <- maybe (pure mempty) (\b' -> hoistEither (first BackendError (codeGen (getBackend b') codeGenNamerSimple ba))) mb
+  ba <- hoistEither (first BuildError (runBuild b udts mempty rts))
+  out <- maybe (pure mempty) (\b' -> hoistEither (first BackendError (codeGen (getBackend b') codeGenNamerSimple mempty ba))) mb
   -- Write out any artefacts
   liftIO . for_ out $ \(f, body) -> do
     let ofile = o </> f

--- a/projector-core/src/Projector/Core/Eval.hs
+++ b/projector-core/src/Projector/Core/Eval.hs
@@ -6,6 +6,7 @@ module Projector.Core.Eval (
   -- * Normalising terms
     whnf
   , nf
+  , substitute
   -- * Fine-grained control
   , Eval
   , runEval
@@ -49,6 +50,11 @@ whnf bnds =
 nf :: Map Name (Expr l a) -> Expr l a -> Expr l a
 nf bnds =
   fst . runEval (EvalState 0) . (nf' <=< substAll bnds)
+
+-- | Safely substitute into an expression.
+substitute :: Map Name (Expr l a) -> Expr l a -> Expr l a
+substitute bnds =
+  fst . runEval (EvalState 0) . substAll bnds
 
 -- -----------------------------------------------------------------------------
 

--- a/projector-html-haskell/test/Test/IO/Projector/Html/Backend/Haskell.hs
+++ b/projector-html-haskell/test/Test/IO/Projector/Html/Backend/Haskell.hs
@@ -57,7 +57,7 @@ prop_hello_world =
                     helloWorld
                   ]
               }
-        modl' <- first Html.renderHtmlError (Html.checkModule mempty modl)
+        modl' <- first Html.renderHtmlError (Html.checkModule mempty mempty modl)
         first renderHaskellError (Html.codeGenModule haskellBackend (ModuleName "Main") modl')
 
 prop_welltyped :: Property
@@ -72,7 +72,7 @@ prop_welltyped =
 modulePropCheck :: ModuleName -> Module (Maybe HtmlType) PrimT SrcAnnotation -> Property
 modulePropCheck mn modl@(Module tys _ _) =
   uncurry ghcProp . either (fail . T.unpack) id $ do
-    modl' <- first Html.renderHtmlError (Html.checkModule tys modl)
+    modl' <- first Html.renderHtmlError (Html.checkModule tys mempty modl)
     first renderHaskellError (Html.codeGenModule haskellBackend mn modl')
 
 moduleProp :: ModuleName -> Module HtmlType PrimT (HtmlType, SrcAnnotation) -> Property

--- a/projector-html-purs/test/Test/IO/Projector/Html/Backend/Purescript.hs
+++ b/projector-html-purs/test/Test/IO/Projector/Html/Backend/Purescript.hs
@@ -62,7 +62,7 @@ moduleProp mn =
 modulePropCheck :: ModuleName -> Module (Maybe HtmlType) PrimT SrcAnnotation -> Property
 modulePropCheck mn modl@(Module tys _ _) =
   uncurry pscProp . either (fail . T.unpack) id $ do
-    modl' <- first Html.renderHtmlError (Html.checkModule tys modl)
+    modl' <- first Html.renderHtmlError (Html.checkModule tys mempty modl)
     first renderPurescriptError (Html.codeGenModule purescriptBackend mn modl')
 
 pscProp mname modl =

--- a/projector-html/src/Projector/Html/Data/Annotation.hs
+++ b/projector-html/src/Projector/Html/Data/Annotation.hs
@@ -33,6 +33,7 @@ data Annotation a
   | ListLiteral a
   | RecordProjection a FieldName
   | TypedHole a
+  | Constant Name
   deriving (Eq, Ord, Show)
 
 type SrcAnnotation = Annotation Range
@@ -78,3 +79,5 @@ renderAnnotation f ann =
       f r <> " in a record projection '" <> fn <> "'"
     TypedHole r ->
       f r <> " in a hole '_'"
+    Constant (Name n) ->
+      "In a constant '" <> n <> "'"

--- a/projector-html/test/Test/Projector/Html/Arbitrary.hs
+++ b/projector-html/test/Test/Projector/Html/Arbitrary.hs
@@ -59,7 +59,7 @@ genWellTypedHtmlModule n decls = do
   either
     (\e -> (fail ("invariant: module was not well-typed!\n" <> show e)))
     pure
-    (checkModule ourDecls (fmap (const EmptyAnnotation) modl))
+    (checkModule ourDecls mempty (fmap (const EmptyAnnotation) modl))
 
 genHtmlType :: HtmlDecls -> Jack HtmlType
 genHtmlType ctx =


### PR DESCRIPTION
This burns in support for platform constants, i.e. values that are different on each platform, but have consistent type. Our main use case is to plumb assets around from Loom, which have different locations for Haskell and Purescript.

There's not a whole lot to this; we pass the names and types of the constants to the typechecker, then we substitute them in before codegen. Substitution is slower than it needs to be because it's "safe"/capture avoidant, we could proobably do this quickly with rewrite rules if we want to live on the edge.
/jury approved @charleso