### PR TITLE
Fix lexer bug

### DIFF
--- a/projector-html/src/Projector/Html/Syntax/Lexer/Tokenise.hs
+++ b/projector-html/src/Projector/Html/Syntax/Lexer/Tokenise.hs
@@ -418,11 +418,11 @@ exprVarId =
 
 exprHtmlStart :: Parser Token
 exprHtmlStart =
-  char '<' *> pure TagOpen <* push HtmlMode <* push TagOpenMode
+  char '<' *> pure TagOpen <* push TagOpenMode
 
 exprHtmlCommentStart :: Parser Token
 exprHtmlCommentStart =
-  string "<!--" *> pure TagCommentStart <* push HtmlMode <* push HtmlCommentMode
+  string "<!--" *> pure TagCommentStart <* push HtmlCommentMode
 
 
 -- -----------------------------------------------------------------------------

--- a/projector-html/test/Test/Projector/Html/Interpreter.hs
+++ b/projector-html/test/Test/Projector/Html/Interpreter.hs
@@ -29,7 +29,7 @@ prop_interpret_unit =
        ma = M.fromList [("a", (at, LibraryFunction (Name "a")))]
        na = M.fromList [(Name "a", a)]
      (_, b) <- first show . checkTemplateIncremental mempty ma $
-       [template|<a>{ a "b" }</a><!-- c --><hr id="d" />e|]
+       [template|<a>{ a "b" }</a><!-- c --><hr id="d" />|]
      h <- first show . interpret mempty na $ b
      pure $
        h
@@ -45,7 +45,6 @@ prop_interpret_unit =
                (Plain "b"))
          , Comment " c "
          , VoidElement "hr" [ Attribute "id" "d" ]
-         , Raw "e"
          ]
 
 

--- a/projector-html/test/Test/Projector/Html/Syntax.hs
+++ b/projector-html/test/Test/Projector/Html/Syntax.hs
@@ -114,6 +114,24 @@ regression_brace =
 { baz quux }
 |]
 
+
+prop_parse_unit_case_html =
+  once $ isRight $ templateFromText this regression_case_html
+
+regression_case_html :: Text
+regression_case_html =
+  T.pack [s|{
+  case foo of
+    bar ->
+      <blink>party</blink>
+    baz ->
+      <marquee>cube</marquee>
+      <i>abcdefg</i>
+    Bap ->
+      <b>hell</b>
+      <i>foo</i>
+}|]
+
 this :: [Char]
 this = "Test.Projector.Html.Syntax"
 


### PR DESCRIPTION
Fixes a terrible bug I introduced by being too aggressive with the maximal-munch HTML rule. Essentially it's a layout and parser rule, but should not have changed the lexical grammar. See #204 for the example, it was ruining `case`.

This change means `<a/>foo<b/>` is a parse error, because `foo` lexes as an expression token. Plain text can only occur within tags. `<a>foo</a><b/>` is perfectly valid.

! @charleso @jystic 

Closes #204 
/jury approved @charleso