### PR TITLE
Stop lexing hyphens in constructors

### DIFF
--- a/projector-html/src/Projector/Html/Syntax/Lexer/Tokenise.hs
+++ b/projector-html/src/Projector/Html/Syntax/Lexer/Tokenise.hs
@@ -443,7 +443,7 @@ exprCommentStart =
 
 exprConId :: Parser Token
 exprConId =
-  fmap (ExprConId . T.pack) ((:) <$> P.upperChar <*> many (P.alphaNumChar <|> P.char '-' <|> P.char '_'))
+  fmap (ExprConId . T.pack) ((:) <$> P.upperChar <*> many (P.alphaNumChar <|> P.char '_'))
 
 exprVarId :: Parser Token
 exprVarId =


### PR DESCRIPTION
Mistake made in #210 

Neither Haskell nor Purescript support hyphens in constructors. We could support them anyway by rewriting them into something else, but there's no real point. This PR updates the lexer so hyphenated constructors are syntax errors.

! @charleso @damncabbage @sphvn 
/jury approved @charleso @damncabbage