### PR TITLE
Fix concat rewrite rule

### DIFF
--- a/projector-html-haskell/src/Projector/Html/Backend/Haskell/Rewrite.hs
+++ b/projector-html-haskell/src/Projector/Html/Backend/Haskell/Rewrite.hs
@@ -104,6 +104,11 @@ rules =
                pure x
              _ ->
                empty)
+      -- concat of a singleton: id
+    , (\case EApp _ (EForeign _ (Name "Projector.Html.Runtime.concat") _) (EList _ [x]) ->
+               pure x
+             _ ->
+               empty)
       -- adjacent raw plaintext nodes can be merged
     , (\case EApp a fh@(EForeign _ (Name "Projector.Html.Runtime.foldHtml") _) (EList b nodes) -> do
                nodes' <- foldRaw nodes


### PR DESCRIPTION
This rule wasn't firing because I'm rewriting bottom-up instead of top-down, so the name "concat" was being qualified before the app was inspected. Here's the qualified version of the rule instead.

This rule is important for simplifying constant strings before they hit GHC. It removes a bunch of redundant `concat ["foo"]`.

! @charleso 
/jury approved @charleso