### PR TITLE
Include constraint location in type error

### DIFF
--- a/projector-core/src/Projector/Core/Pretty.hs
+++ b/projector-core/src/Projector/Core/Pretty.hs
@@ -130,6 +130,8 @@ ppTypeError' err =
       WL.annotate a . WL.hang 2 $
         text "Found hole with type:"
           WL.<$$> text (ppType ty)
+    Annotated a te ->
+      WL.annotate a $ ppTypeError' te
 
 
 annNL :: a -> Doc a -> Doc a

--- a/projector-core/test/Test/Projector/Core/Check.hs
+++ b/projector-core/test/Test/Projector/Core/Check.hs
@@ -142,7 +142,7 @@ prop_record_unit_prj_extra =
   once $
     typeCheck dRecord rexpr
     ===
-    Left [ ExtraRecordField nRecord (FieldName "quux") (TVar (TypeName "b"), ()) () ]
+    Left [ Annotated () (ExtraRecordField nRecord (FieldName "quux") (TVar (TypeName "b"), ()) ()) ]
   where
     rexpr =
       EApp ()


### PR DESCRIPTION
Include the location of the constraint alongside every type error.

We're currently including the source locations for each _type_ in a type mismatch, but we're not including the source location that implied those two types were equal.

This means there are now three locations in most type errors. Will focus on making this pretty once people are using projector a little more.

Closes #198 

! @charleso @jystic 
/jury approved @charleso