### PR TITLE
Solve top-down and fix type holes

### DIFF
--- a/projector-core/src/Projector/Core/Check.hs
+++ b/projector-core/src/Projector/Core/Check.hs
@@ -394,7 +394,7 @@ data Constraint l a
 addConstraint :: Ground l => Constraint l a -> Check l a ()
 addConstraint c =
   Check . lift $
-    modify' (\s -> s { sConstraints = D.snoc (sConstraints s) c })
+    modify' (\s -> s { sConstraints = D.cons c (sConstraints s) })
 
 
 -- -----------------------------------------------------------------------------
@@ -655,9 +655,10 @@ substituteType subs top ty =
       maybe
         ty
         (\sty ->
+          let res = substituteType subs False sty in
           if top
-          then IHole a x (Just sty)
-          else substituteType subs False sty)
+          then IHole a x (Just res)
+          else res)
         (M.lookup x (unSubstitutions subs))
 
     IArrow a t1 t2 ->


### PR DESCRIPTION
- Solve the constraints in reverse order, seems to fix #229 
- Recursively substitute into type holes, makes them actually useful

I don't quite understand why reversing the order is correct, I have only observed it being correct and producing a much more complete substitution set. Suspect the previous order was leading the solver to skip some intermediate constraints if they didn't contribute to the outermost type.

I will probably try to understand why this works and to write some tests before merging it.

Closes #228 
Closes #229 

! @charleso @sphvn 
/jury approved @charleso