### PR TITLE
Fix Purescript record patterns

### DIFF
--- a/projector-cli/main/slideshow.hs
+++ b/projector-cli/main/slideshow.hs
@@ -305,7 +305,7 @@ renderExpr' :: (e -> ReplError) -> Backend.Backend SrcAnnotation e -> Core.Name 
 renderExpr' e b n expr =
   Repl $ do
     lift (hoistEither (bimap e ReplSuccess
-      (Backend.renderExpr b n expr)))
+      (Backend.renderExpr b mempty n expr)))
 
 
 err :: ReplError -> Repl a

--- a/projector-html-haskell/src/Projector/Html/Backend/Haskell.hs
+++ b/projector-html-haskell/src/Projector/Html/Backend/Haskell.hs
@@ -110,8 +110,8 @@ htmlConstructors =
 
 -- -----------------------------------------------------------------------------
 
-renderModule :: ModuleName -> Module HtmlType PrimT (HtmlType, a) -> Either HaskellError (FilePath, Text)
-renderModule mn@(ModuleName n) m = do
+renderModule :: HtmlDecls -> ModuleName -> Module HtmlType PrimT (HtmlType, a) -> Either HaskellError (FilePath, Text)
+renderModule _decls mn@(ModuleName n) m = do
   let pragmas = [
           "{-# LANGUAGE NoImplicitPrelude #-}"
         , "{-# LANGUAGE OverloadedStrings #-}"
@@ -134,8 +134,8 @@ renderModule mn@(ModuleName n) m = do
      , decls
      ])
 
-renderExpr :: Name -> HtmlExpr (HtmlType, a) -> Either HaskellError Text
-renderExpr n =
+renderExpr :: HtmlDecls -> Name -> HtmlExpr (HtmlType, a) -> Either HaskellError Text
+renderExpr _decls n =
   fmap (T.pack . TH.pprint) . genExpDec n . toHaskellExpr . rewriteExpr
 
 genImport :: ModuleName -> Imports -> Text

--- a/projector-html/src/Projector/Html/Data/Backend.hs
+++ b/projector-html/src/Projector/Html/Data/Backend.hs
@@ -26,16 +26,16 @@ import           System.IO (FilePath)
 -- platform source code, with a validation pass derived from a set of
 -- predicates.
 data Backend a e = Backend {
-    renderModule :: ModuleName -> Module HtmlType PrimT (HtmlType, a) -> Either e (FilePath, Text)
-  , renderExpr :: Name -> HtmlExpr (HtmlType, a) -> Either e Text
+    renderModule :: HtmlDecls -> ModuleName -> Module HtmlType PrimT (HtmlType, a) -> Either e (FilePath, Text)
+  , renderExpr :: HtmlDecls -> Name -> HtmlExpr (HtmlType, a) -> Either e Text
   , predicates :: [Predicate e]
   }
 
 instance Functor (Backend a) where
   fmap f (Backend m e p) =
     Backend {
-        renderModule = fmap (fmap (first f)) m
-      , renderExpr = fmap (fmap (first f)) e
+        renderModule = fmap (fmap (fmap (first f))) m
+      , renderExpr = fmap (fmap (fmap (first f))) e
       , predicates = fmap (fmap f) p
       }
 


### PR DESCRIPTION
Projector's syntax currently allows Haskell-style pattern matching on records, like `Foo a b c`. Purescript doesn't permit this, since its record rows are not ordered.

In order to generate a valid Purescript pattern match on records, we need to look up its type.

Bit of refactoring required to plumb the type declarations around, plus the relevant string-slinging.
/jury approved @charleso @sphvn