### PR TITLE
Propagate annotations when substituting

### DIFF
--- a/projector-core/src/Projector/Core/Eval.hs
+++ b/projector-core/src/Projector/Core/Eval.hs
@@ -288,7 +288,7 @@ subst' :: Map Name (Expr l a) -> Set Name -> Expr l a -> FixT (Eval l a) (Expr l
 subst' subs free expr =
   case expr of
     EVar a z ->
-      mcase (M.lookup z subs) (pure expr) (U.progress . setAnnotation a)
+      mcase (M.lookup z subs) (pure (setAnnotation a expr)) (U.progress . setAnnotation a)
 
     ELam a z ty f ->
       if S.member z free


### PR DESCRIPTION
This fixes an error reporting bug that was most painful/visible when using constructor functions.

Any function you inline *before* typechecking would lead to error locations inside the definition, not the use site. Since constructor functions don't even have source locations, this led to completely inscrutable messages.
/jury approved @charleso @sphvn