### PR TITLE
Take over generation of datatypes

### DIFF
--- a/projector-cli/main/cinema.hs
+++ b/projector-cli/main/cinema.hs
@@ -18,6 +18,7 @@ import qualified Machinator.Core as MC
 
 import           P
 
+import qualified Projector.Core as PC
 import           Projector.Html
 import           Projector.Html.Backend
 import           Projector.Html.Backend.Haskell
@@ -147,8 +148,8 @@ parseDataFiles fps = do
   defs <- for fps $ \f -> do
     m <- liftIO (T.readFile f)
     MC.Versioned _ (MC.DefinitionFile _ defs) <- hoistEither (first (DataError . T.pack . show) (MC.parseDefinitionFile f m))
-    pure defs
-  pure (UserDataTypes (HMC.machinatorDecls (fold defs)))
+    pure (f, PC.unTypeDecls (HMC.machinatorDecls defs))
+  pure (UserDataTypes defs)
 
 getBackend :: BackendT -> Backend a BackendError
 getBackend b =


### PR DESCRIPTION
Projector now needs to be in charge of datatype generation, in order to support more complicated HTML representations (the sort with pesky type parameters).

Once we decided to allow HTML and attributes into datatypes, this change became inevitable.