### PR TITLE
Pux backend

### DIFF
--- a/projector-html-haskell/src/Projector/Html/Backend/Haskell.hs
+++ b/projector-html-haskell/src/Projector/Html/Backend/Haskell.hs
@@ -147,6 +147,8 @@ genImport (ModuleName n) imports =
       "import " <> n <> " (" <> T.intercalate ", " (fmap unName funs) <> ")"
     ImportQualified ->
       "import qualified " <> n
+    ImportQualifiedAs (ModuleName mn) ->
+      "import qualified " <> n <> " as " <> mn
 
 genModule :: HaskellModule (HtmlType, a) -> Either HaskellError [TH.Dec]
 genModule (Module ts _ es) = do

--- a/projector-html-purs/ambiata-projector-html-purs.cabal
+++ b/projector-html-purs/ambiata-projector-html-purs.cabal
@@ -19,6 +19,7 @@ library
                      , annotated-wl-pprint             == 0.7.*
                      , containers                      == 0.5.*
                      , text                            == 1.2.*
+                     , transformers                    >= 0.4        && < 0.7
 
   ghc-options:
                        -Wall
@@ -30,7 +31,7 @@ library
                        Paths_ambiata_projector_html_purs
 
                        Projector.Html.Backend.Purescript
-
+                       Projector.Html.Backend.Purescript.Rewrite
 
 test-suite test-io
   type:                exitcode-stdio-1.0

--- a/projector-html-purs/src/Projector/Html/Backend/Purescript/Rewrite.hs
+++ b/projector-html-purs/src/Projector/Html/Backend/Purescript/Rewrite.hs
@@ -56,9 +56,9 @@ rules mmn =
              _ ->
                empty)
 
-    -- FIXME this is a bad bad hack, probably need to filter out comments.
-    , (\case ECon a (Constructor "Comment") _ [str] ->
-               pure (apply (textNode a) [str])
+    -- Erase HTML comments, they have no meaning at runtime
+    , (\case ECon a (Constructor "Comment") _ _ ->
+               pure (blank a)
              _ ->
                empty)
 
@@ -184,6 +184,10 @@ disqualify (ModuleName mn) (Name n) = do
 apply :: Expr PrimT a -> [Expr PrimT a] -> Expr PrimT a
 apply f =
   foldl' (EApp (extractAnnotation f)) f
+
+blank :: a -> Expr PrimT a
+blank a =
+  EForeign a (Name "Projector.Html.Runtime.Pux.blank") CL.tHtml
 
 textNode :: a -> Expr PrimT a
 textNode a =

--- a/projector-html-purs/test/Test/IO/Projector/Html/Backend/Purescript.hs
+++ b/projector-html-purs/test/Test/IO/Projector/Html/Backend/Purescript.hs
@@ -15,6 +15,7 @@ import           Disorder.Jack
 import           P
 
 import qualified Projector.Html as Html
+import           Projector.Html.Backend (checkModule)
 import           Projector.Html.Backend.Purescript
 import           Projector.Html.Data.Annotation
 import           Projector.Html.Data.Module
@@ -35,7 +36,7 @@ prop_empty_module =
 
 prop_library_module =
   once . modulePropCheck baseDecls (ModuleName "Test.Purescript.Library") $ Module {
-      moduleTypes = baseDecls
+      moduleTypes = mempty
     , moduleImports = mempty
     , moduleExprs = M.fromList [
           helloWorld
@@ -46,11 +47,9 @@ prop_welltyped :: Property
 prop_welltyped =
   gamble genHtmlTypeDecls $ \decls ->
     gamble (chooseInt (0,  100)) $ \k ->
-      gamble (genWellTypedHtmlModule k decls) $ \modl ->
+      gamble (genWellTypedHtmlModule k decls `suchThat` (isRight . checkModule purescriptBackend)) $ \modl ->
         moduleProp decls (ModuleName "Test.Purescript.Arbitrary.WellTyped") $ modl {
-            -- TODO once the backend actually does something, remove this setter
-            moduleTypes = decls
-          , moduleExprs = moduleExprs modl
+            moduleExprs = moduleExprs modl
           }
 
 -- -----------------------------------------------------------------------------

--- a/projector-html-runtime-purs/bower.json
+++ b/projector-html-runtime-purs/bower.json
@@ -7,7 +7,6 @@
     "output"
   ],
   "dependencies": {
-    "purescript-p": "git@github.com:ambiata/p.purs#0179678a83d5289863bdb04a81d032e7858640f7",
     "purescript-arrays": "^1.0.0",
     "purescript-control": "^1.0.0",
     "purescript-enums": "^1.1.0",
@@ -24,7 +23,8 @@
     "purescript-strings": "^1.0.0",
     "purescript-tailrec": "^1.0.0",
     "purescript-tuples": "^1.0.0",
-    "purescript-unfoldable": "^1.0.0"
+    "purescript-unfoldable": "^1.0.0",
+    "purescript-pux": "^6.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^1.0.0"

--- a/projector-html-runtime-purs/bower.json
+++ b/projector-html-runtime-purs/bower.json
@@ -8,22 +8,8 @@
   ],
   "dependencies": {
     "purescript-arrays": "^1.0.0",
-    "purescript-control": "^1.0.0",
-    "purescript-enums": "^1.1.0",
-    "purescript-eff": "^1.0.0",
-    "purescript-either": "^1.0.0",
-    "purescript-foldable-traversable": "^1.0.0",
-    "purescript-maps": "^1.1.0",
-    "purescript-maybe": "^1.0.0",
-    "purescript-monoid": "^1.0.0",
-    "purescript-nonempty": "^1.1.1",
-    "purescript-partial": "^1.1.0",
-    "purescript-prelude": "^1.1.0",
-    "purescript-random": "^1.0.0",
+    "purescript-prelude": "^1.0.0",
     "purescript-strings": "^1.0.0",
-    "purescript-tailrec": "^1.0.0",
-    "purescript-tuples": "^1.0.0",
-    "purescript-unfoldable": "^1.0.0",
     "purescript-pux": "^6.0.1"
   },
   "devDependencies": {

--- a/projector-html-runtime-purs/src/Projector/Html/Runtime.purs
+++ b/projector-html-runtime-purs/src/Projector/Html/Runtime.purs
@@ -1,8 +1,14 @@
 module Projector.Html.Runtime (
     append
   , concat
+  , fold
+  , isEmpty
+  , map
   ) where
 
+import Control.Monad as Monad
+import Data.Array as Array
+import Data.Functor as Functor
 import Data.String as String
 import Prelude ((<>))
 
@@ -13,3 +19,15 @@ append =
 concat :: Array String -> String
 concat =
   String.joinWith ""
+
+fold :: forall a. Array (Array a) -> Array a
+fold =
+  Monad.join
+
+isEmpty :: forall a. Array a -> Boolean
+isEmpty =
+  Array.null
+
+map :: forall f a b. Functor.Functor f => (a -> b) -> f a -> f b
+map =
+  Functor.map

--- a/projector-html-runtime-purs/src/Projector/Html/Runtime/Pux.purs
+++ b/projector-html-runtime-purs/src/Projector/Html/Runtime/Pux.purs
@@ -1,0 +1,55 @@
+module Projector.Html.Runtime.Pux (
+    Html
+  , text
+  , textUnescaped
+  , parent
+  , void
+  , fold
+  , blank
+  , attr
+  ) where
+
+import Data.Array as Array
+import Data.Function.Uncurried (runFn3)
+import Prelude
+import Pux.Html.Attributes (attr) as Pux
+import Pux.Html.Elements (Html, Attribute, element, text) as Pux
+
+type Html ev = Array (Pux.Html ev)
+
+
+-- Pux 6 Html doesn't have a valid fold/concat, so we resort to this
+-- awful hack: Everything must be an array.
+--
+-- The nested array concatenation here will lead to remarkably poor
+-- performance. We just have to live with this until we can upgrade
+-- to the newer version of Pux, or something else based on Smolder.
+-- It may also be straightforward to use rewrite rules to install an array builder.
+
+text :: forall ev. String -> Array (Pux.Html ev)
+text =
+  Array.singleton <<< Pux.text
+
+textUnescaped :: forall ev. String -> Array (Pux.Html ev)
+textUnescaped =
+  Array.singleton <<< Pux.text
+
+parent :: forall ev. String -> Array (Pux.Attribute ev) -> Array (Array (Pux.Html ev)) -> Array (Pux.Html ev)
+parent name attrs =
+  Array.singleton <<< runFn3 Pux.element name attrs <<< Array.concat
+
+void :: forall ev. String -> Array (Pux.Attribute ev) -> Array (Pux.Html ev)
+void name attrs =
+  Array.singleton (runFn3 Pux.element name attrs [])
+
+fold :: forall ev. Array (Array (Pux.Html ev)) -> Array (Pux.Html ev)
+fold =
+  Array.concat
+
+blank :: forall ev. Array (Pux.Html ev)
+blank =
+  []
+
+attr :: forall ev. String -> String -> Pux.Attribute ev
+attr =
+  Pux.attr

--- a/projector-html/src/Projector/Html/Data/Module.hs
+++ b/projector-html/src/Projector/Html/Data/Module.hs
@@ -78,4 +78,5 @@ data Imports
   = OpenImport
   | OnlyImport [Name]
   | ImportQualified
+  | ImportQualifiedAs ModuleName
   deriving (Eq, Ord, Show)


### PR DESCRIPTION
Hopefully this code is fairly self-contained, it should be easy to adapt to any typed language where the event is a threaded type parameter (`forall ev. Html ev`).

This will be slow-ish at runtime. If this is observable and unacceptable, there are plenty of remedies available. Swapping out the runtime `Array` for an ST-based array builder, that should pretty much do it.

All current codebases compile fairly quickly with one exception: those Int and Double types defined somewhere in manor.

! @charleso @sphvn 
/jury approved @charleso